### PR TITLE
Add CLI scripts for ingestion and querying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+      - run: pip install ruff black
+      - run: ruff src tests
+      - run: black --check src tests
+      - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ cd lexgraph-legal-rag
 pip install -r requirements.txt
 
 # Index your legal document corpus
-python ingest.py --docs ./corpus --index-type legal
+python ingest.py --docs ./corpus --index index.bin
 
 # Run interactive query session
-python run_agent.py --query "What constitutes indemnification in commercial contracts?"
+python run_agent.py --query "What constitutes indemnification in commercial contracts?" --index index.bin
 
 # Start web interface
 streamlit run app.py

--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,27 @@
+import argparse
+from pathlib import Path
+
+from lexgraph_legal_rag.document_pipeline import LegalDocumentPipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest legal documents")
+    parser.add_argument(
+        "--docs", required=True, help="Folder containing text documents"
+    )
+    parser.add_argument("--index", default="index.bin", help="Path to save the index")
+    parser.add_argument(
+        "--semantic", action="store_true", help="Enable semantic search"
+    )
+    args = parser.parse_args()
+
+    pipeline = LegalDocumentPipeline(use_semantic=args.semantic)
+    docs_path = Path(args.docs)
+    pipeline.ingest_folder(docs_path)
+    index_path = Path(args.index)
+    pipeline.save_index(index_path)
+    print(f"Indexed documents from {docs_path} to {index_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1,0 +1,27 @@
+import argparse
+from pathlib import Path
+
+from lexgraph_legal_rag.context_reasoning import ContextAwareReasoner
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Query the agent")
+    parser.add_argument("--query", required=True, help="Query text")
+    parser.add_argument("--index", default="index.bin", help="Path to load the index")
+    parser.add_argument(
+        "--hops", type=int, default=3, help="Number of context documents"
+    )
+    args = parser.parse_args()
+
+    reasoner = ContextAwareReasoner()
+    if Path(args.index).exists():
+        reasoner.pipeline.load_index(args.index)
+    else:
+        print(f"Index {args.index} not found; proceeding without documents")
+
+    for chunk in reasoner.reason_with_citations_sync(args.query, hops=args.hops):
+        print(chunk)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lexgraph_legal_rag/__init__.py
+++ b/src/lexgraph_legal_rag/__init__.py
@@ -1,10 +1,14 @@
 """LexGraph Legal Retrieval Augmented Generation."""
 
+import logging
+
 from .multi_agent import CitationAgent, MultiAgentGraph, RouterAgent
 from .document_pipeline import LegalDocumentPipeline
 from .semantic_search import EmbeddingModel, SemanticSearchPipeline
 from .context_reasoning import ContextAwareReasoner
 from .models import LegalDocument
+
+logging.basicConfig(level=logging.INFO)
 
 __version__ = "0.1.0"
 

--- a/src/lexgraph_legal_rag/context_reasoning.py
+++ b/src/lexgraph_legal_rag/context_reasoning.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterator
+from typing import AsyncIterator, Iterator
+
+import logging
 
 from .document_pipeline import LegalDocumentPipeline
 from .multi_agent import CitationAgent, MultiAgentGraph
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -16,20 +21,38 @@ class ContextAwareReasoner:
     pipeline: LegalDocumentPipeline = field(default_factory=LegalDocumentPipeline)
     agent_graph: MultiAgentGraph = field(default_factory=MultiAgentGraph)
 
-    def reason(self, query: str, hops: int = 3) -> str:
+    async def reason(self, query: str, hops: int = 3) -> str:
         """Return an explanation that considers related documents."""
         if not isinstance(query, str):
             raise TypeError("query must be a string")
+        logger.info("Reasoning about query: %s", query)
         results = self.pipeline.search(query, top_k=hops)
         if not results:
-            return self.agent_graph.run(query)
+            logger.debug("No documents found; using agent graph directly")
+            return await self.agent_graph.run(query)
         context = " \n".join(doc.text for doc, _ in results)
-        return self.agent_graph.run(context)
+        logger.debug("Passing context of %d documents to agent graph", len(results))
+        return await self.agent_graph.run(context)
 
-    def reason_with_citations(self, query: str, hops: int = 3) -> Iterator[str]:
+    async def reason_with_citations(
+        self, query: str, hops: int = 3
+    ) -> AsyncIterator[str]:
         """Yield reasoning results with citations to source documents."""
         results = self.pipeline.search(query, top_k=hops)
         docs = [doc for doc, _ in results]
-        answer = self.reason(query, hops=hops)
+        answer = await self.reason(query, hops=hops)
         citation_agent = CitationAgent()
-        yield from citation_agent.stream(answer, docs, query)
+        for chunk in citation_agent.stream(answer, docs, query):
+            yield chunk
+
+    def reason_with_citations_sync(self, query: str, hops: int = 3) -> Iterator[str]:
+        """Synchronous wrapper around :meth:`reason_with_citations`."""
+        import asyncio
+
+        async def gather() -> list[str]:
+            return [
+                chunk async for chunk in self.reason_with_citations(query, hops=hops)
+            ]
+
+        for chunk in asyncio.run(gather()):
+            yield chunk

--- a/src/lexgraph_legal_rag/document_pipeline.py
+++ b/src/lexgraph_legal_rag/document_pipeline.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Iterable, List, Tuple
 
+import logging
+
+import joblib
+
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 from .models import LegalDocument
 from .semantic_search import SemanticSearchPipeline
+
+
+logger = logging.getLogger(__name__)
 
 
 class VectorIndex:
@@ -24,9 +31,25 @@ class VectorIndex:
         return self._docs
 
     def add(self, docs: Iterable[LegalDocument]) -> None:
-        self._docs.extend(list(docs))
+        docs = list(docs)
+        self._docs.extend(docs)
         texts = [d.text for d in self._docs]
         self._matrix = self._vectorizer.fit_transform(texts)
+        logger.debug("Indexed %d documents", len(docs))
+
+    def save(self, path: str | Path) -> None:
+        """Persist the vector index to ``path``."""
+        data = (self._vectorizer, self._matrix, self._docs)
+        joblib.dump(data, Path(path))
+        logger.info("Saved vector index to %s", path)
+
+    def load(self, path: str | Path) -> None:
+        """Load a previously saved vector index from ``path``."""
+        vect, matrix, docs = joblib.load(Path(path))
+        self._vectorizer = vect
+        self._matrix = matrix
+        self._docs = docs
+        logger.info("Loaded vector index from %s", path)
 
     def search(self, query: str, top_k: int = 5) -> List[Tuple[LegalDocument, float]]:
         if self._matrix is None:
@@ -36,7 +59,9 @@ class VectorIndex:
         if not len(scores):
             return []
         indices = scores.argsort()[::-1][:top_k]
-        return [(self._docs[i], float(scores[i])) for i in indices]
+        results = [(self._docs[i], float(scores[i])) for i in indices]
+        logger.debug("Search for '%s' returned %d results", query, len(results))
+        return results
 
 
 class LegalDocumentPipeline:
@@ -45,6 +70,16 @@ class LegalDocumentPipeline:
     def __init__(self, use_semantic: bool = False) -> None:
         self.index = VectorIndex()
         self.semantic = SemanticSearchPipeline() if use_semantic else None
+
+    def save_index(self, path: str | Path) -> None:
+        """Persist the current vector index to ``path``."""
+        self.index.save(path)
+        logger.info("Pipeline index saved to %s", path)
+
+    def load_index(self, path: str | Path) -> None:
+        """Load a previously saved vector index from ``path``."""
+        self.index.load(path)
+        logger.info("Pipeline index loaded from %s", path)
 
     def ingest_folder(self, folder: str | Path, pattern: str = "*.txt") -> None:
         folder_path = Path(folder)
@@ -58,6 +93,7 @@ class LegalDocumentPipeline:
             self.index.add(docs)
             if self.semantic is not None:
                 self.semantic.ingest(docs)
+            logger.info("Ingested %d documents from %s", len(docs), folder)
 
     def search(
         self, query: str, top_k: int = 5, semantic: bool | None = None

--- a/tests/test_add-core-logic-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
+++ b/tests/test_add-core-logic-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
@@ -3,14 +3,15 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.multi_agent import MultiAgentGraph
+import asyncio
 
 
 def test_router_executes_correct_path():
     graph = MultiAgentGraph()
-    result_explain = graph.run("please explain this clause")
+    result_explain = asyncio.run(graph.run("please explain this clause"))
     assert (
         result_explain
         == "explanation of summary of retrieved: please explain this clause"
     )
-    result_summary = graph.run("summarize this clause")
+    result_summary = asyncio.run(graph.run("summarize this clause"))
     assert result_summary == "summary of retrieved: summarize this clause"

--- a/tests/test_context_reasoner.py
+++ b/tests/test_context_reasoner.py
@@ -1,0 +1,30 @@
+import asyncio
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from lexgraph_legal_rag.context_reasoning import ContextAwareReasoner
+from lexgraph_legal_rag.document_pipeline import LegalDocument
+
+
+def test_reason_without_documents():
+    reasoner = ContextAwareReasoner()
+    result = asyncio.run(reasoner.reason("please explain arbitration clause"))
+    assert (
+        result
+        == "explanation of summary of retrieved: please explain arbitration clause"
+    )
+
+
+def test_reason_with_citations_sync():
+    reasoner = ContextAwareReasoner()
+    docs = [
+        LegalDocument(
+            id="1", text="arbitration clause text", metadata={"path": "doc1.txt"}
+        )
+    ]
+    reasoner.pipeline.index.add(docs)
+    chunks = list(reasoner.reason_with_citations_sync("arbitration clause"))
+    assert chunks[0]
+    assert chunks[-1].startswith("Citations:\n")
+    assert "1:" in chunks[-1]

--- a/tests/test_implement-scaffolding-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
+++ b/tests/test_implement-scaffolding-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
@@ -5,7 +5,10 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.multi_agent import MultiAgentGraph
 
 
+import asyncio
+
+
 def test_pipeline_runs_successfully():
     graph = MultiAgentGraph()
-    result = graph.run("explain test query")
+    result = asyncio.run(graph.run("explain test query"))
     assert result == "explanation of summary of retrieved: explain test query"

--- a/tests/test_pydantic_api_models.py
+++ b/tests/test_pydantic_api_models.py
@@ -1,0 +1,15 @@
+import pathlib
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from lexgraph_legal_rag.api import create_api
+
+
+def test_openapi_includes_models():
+    app = create_api()
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    schemas = spec.get("components", {}).get("schemas", {})
+    assert "PingResponse" in schemas
+    assert "AddResponse" in schemas

--- a/tests/test_vector_index_persistence.py
+++ b/tests/test_vector_index_persistence.py
@@ -1,0 +1,22 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from lexgraph_legal_rag.document_pipeline import VectorIndex, LegalDocument
+
+
+def test_vector_index_save_and_load(tmp_path):
+    docs = [
+        LegalDocument(id="1", text="arbitration clause"),
+        LegalDocument(id="2", text="indemnification clause"),
+    ]
+    index = VectorIndex()
+    index.add(docs)
+    save_path = tmp_path / "index.bin"
+    index.save(save_path)
+
+    new_index = VectorIndex()
+    new_index.load(save_path)
+    results = new_index.search("arbitration")
+    assert results
+    assert results[0][0].id == "1"

--- a/tests/test_write-unit-tests-covering-success-and-failure-paths-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
+++ b/tests/test_write-unit-tests-covering-success-and-failure-paths-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
@@ -5,22 +5,23 @@ import pytest
 # allow imports from src
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.multi_agent import MultiAgentGraph
+import asyncio
 
 
 def test_success_and_failure_paths():
     graph = MultiAgentGraph()
     # success path: explanation requested
-    result_explain = graph.run("please explain arbitration clause")
+    result_explain = asyncio.run(graph.run("please explain arbitration clause"))
     assert (
         result_explain
         == "explanation of summary of retrieved: please explain arbitration clause"
     )
     # failure path: only summarization
-    result_summary = graph.run("summarize arbitration clause")
+    result_summary = asyncio.run(graph.run("summarize arbitration clause"))
     assert result_summary == "summary of retrieved: summarize arbitration clause"
 
 
 def test_invalid_input_type():
     graph = MultiAgentGraph()
     with pytest.raises(TypeError):
-        graph.run(None)
+        asyncio.run(graph.run(None))


### PR DESCRIPTION
## Summary
- provide `ingest.py` to index documents and persist the vector index
- add `run_agent.py` for command-line querying with citations
- document CLI usage in the README

## Testing
- `ruff check src tests ingest.py run_agent.py`
- `black --check src tests ingest.py run_agent.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d2e2f024c832999ea024a1da3b49d