### PR TITLE
Add semantic index persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,5 @@
 
 ## ✨ Features
 - feat(search): add semantic search pipeline
+- feat(search): persist semantic search indices
+- deps: require joblib for persistence

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ cd lexgraph-legal-rag
 pip install -r requirements.txt
 
 # Index your legal document corpus
-python ingest.py --docs ./corpus --index index.bin
+# (add `--semantic` to enable semantic search)
+python ingest.py --docs ./corpus --index index.bin --semantic
 
 # Run interactive query session
 python run_agent.py --query "What constitutes indemnification in commercial contracts?" --index index.bin
@@ -27,6 +28,10 @@ python run_agent.py --query "What constitutes indemnification in commercial cont
 # Start web interface
 streamlit run app.py
 ```
+
+The pipeline saves both vector and semantic indices. The semantic index
+is stored alongside the main index with a `.sem` suffix and loads
+automatically when present.
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "scikit-learn",
     "fastapi>=0.115",
     "httpx",
+    "joblib",
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest>=7.0
 scikit-learn>=1.7
 fastapi>=0.115
 httpx
+joblib

--- a/src/lexgraph_legal_rag/document_pipeline.py
+++ b/src/lexgraph_legal_rag/document_pipeline.py
@@ -74,11 +74,21 @@ class LegalDocumentPipeline:
     def save_index(self, path: str | Path) -> None:
         """Persist the current vector index to ``path``."""
         self.index.save(path)
+        if self.semantic is not None:
+            base = Path(path)
+            semantic_path = base.with_suffix(base.suffix + ".sem")
+            self.semantic.save(semantic_path)
         logger.info("Pipeline index saved to %s", path)
 
     def load_index(self, path: str | Path) -> None:
         """Load a previously saved vector index from ``path``."""
         self.index.load(path)
+        base = Path(path)
+        semantic_path = base.with_suffix(base.suffix + ".sem")
+        if semantic_path.exists():
+            if self.semantic is None:
+                self.semantic = SemanticSearchPipeline()
+            self.semantic.load(semantic_path)
         logger.info("Pipeline index loaded from %s", path)
 
     def ingest_folder(self, folder: str | Path, pattern: str = "*.txt") -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pathlib
+import sys
+
+# Ensure tests can import project modules without altering each test file
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_add-core-logic-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
+++ b/tests/test_add-core-logic-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
@@ -1,7 +1,3 @@
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.multi_agent import MultiAgentGraph
 import asyncio
 

--- a/tests/test_context_reasoner.py
+++ b/tests/test_context_reasoner.py
@@ -1,8 +1,5 @@
 import asyncio
-import pathlib
-import sys
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.context_reasoning import ContextAwareReasoner
 from lexgraph_legal_rag.document_pipeline import LegalDocument
 

--- a/tests/test_default-version-fallback.py
+++ b/tests/test_default-version-fallback.py
@@ -1,8 +1,5 @@
-import pathlib
-import sys
 from fastapi.testclient import TestClient
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.api import create_api
 
 

--- a/tests/test_define-versioning-scheme.py
+++ b/tests/test_define-versioning-scheme.py
@@ -1,9 +1,6 @@
-import pathlib
-import sys
 from fastapi.testclient import TestClient
 
 # allow imports from src
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.api import create_api
 
 

--- a/tests/test_empty_search.py
+++ b/tests/test_empty_search.py
@@ -1,0 +1,12 @@
+from lexgraph_legal_rag.document_pipeline import VectorIndex
+from lexgraph_legal_rag.semantic_search import SemanticSearchPipeline
+
+
+def test_vector_index_search_empty():
+    index = VectorIndex()
+    assert index.search("anything") == []
+
+
+def test_semantic_pipeline_search_empty():
+    pipeline = SemanticSearchPipeline()
+    assert pipeline.search("anything") == []

--- a/tests/test_implement-scaffolding-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
+++ b/tests/test_implement-scaffolding-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
@@ -1,7 +1,3 @@
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.multi_agent import MultiAgentGraph
 
 

--- a/tests/test_implement-versioned-routing.py
+++ b/tests/test_implement-versioned-routing.py
@@ -1,8 +1,5 @@
-import pathlib
-import sys
 from fastapi.testclient import TestClient
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.api import create_api
 
 

--- a/tests/test_pydantic_api_models.py
+++ b/tests/test_pydantic_api_models.py
@@ -1,8 +1,5 @@
-import pathlib
-import sys
 from fastapi.testclient import TestClient
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.api import create_api
 
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,7 +1,3 @@
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 import lexgraph_legal_rag.sample as sample
 
 

--- a/tests/test_semantic_index_persistence.py
+++ b/tests/test_semantic_index_persistence.py
@@ -1,0 +1,19 @@
+from lexgraph_legal_rag.document_pipeline import LegalDocumentPipeline, LegalDocument
+
+
+def test_semantic_index_save_and_load(tmp_path):
+    docs = [
+        LegalDocument(id="1", text="arbitration clause"),
+        LegalDocument(id="2", text="indemnification clause"),
+    ]
+    pipeline = LegalDocumentPipeline(use_semantic=True)
+    pipeline.index.add(docs)
+    pipeline.semantic.ingest(docs)
+    save_path = tmp_path / "index.bin"
+    pipeline.save_index(save_path)
+
+    new_pipeline = LegalDocumentPipeline(use_semantic=False)
+    new_pipeline.load_index(save_path)
+    results = new_pipeline.search("arbitration", semantic=True)
+    assert results
+    assert results[0][0].id == "1"

--- a/tests/test_vector_index_persistence.py
+++ b/tests/test_vector_index_persistence.py
@@ -1,7 +1,3 @@
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.document_pipeline import VectorIndex, LegalDocument
 
 

--- a/tests/test_write-unit-tests-covering-success-and-failure-paths-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
+++ b/tests/test_write-unit-tests-covering-success-and-failure-paths-for-multi-agent-architecture-recursive-graph-of-specialized-tools-retriever-summarizer-clause-explainer-that-intelligently-decide-when-to-call-one-another.py
@@ -1,9 +1,6 @@
-import pathlib
-import sys
 import pytest
 
 # allow imports from src
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from lexgraph_legal_rag.multi_agent import MultiAgentGraph
 import asyncio
 


### PR DESCRIPTION
## Summary
- persist semantic search index to disk
- reload semantic index when loading vector index
- add tests for semantic index persistence
- refine path handling when saving semantic index
- add joblib as an explicit dependency
- document joblib requirement in changelog
- document semantic index persistence in README
- share `src` path via `tests/conftest.py`
- validate empty searches return no results

## Testing
- `ruff check .`
- `black --check .`
- `bandit -r src -ll`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860001195dc8329a16bcf2a2797700b

## Summary by Sourcery

Add persistent storage for semantic search indices and integrate automatic save/load alongside vector indices using joblib.

New Features:
- Persist semantic search index to disk with save and load methods integrated into the document pipeline.
- Automatically reload semantic index when loading the vector index if a .sem file is present.

Enhancements:
- Use a .sem file suffix and refined path handling for semantic index files in the pipeline.

Build:
- Add joblib as an explicit dependency for index persistence.

Documentation:
- Update README to include --semantic flag and describe semantic index persistence.
- Document joblib requirement and persistence feature in CHANGELOG.

Tests:
- Add unit tests for semantic index persistence and for validating empty search results.

Chores:
- Introduce tests/conftest.py to share the src path across test files.